### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ android:
     - build-tools-23.0.3
     - android-23
     - extra-android-m2repository
-  licenses:
-    - android-sdk-license-5be876d5
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: android
 
 android:
   components:
-    - tools
+    - tools # to get the new `repository-11.xml`
+    - tools # see https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943)
     - build-tools-23.0.3
     - android-23
     - extra-android-m2repository


### PR DESCRIPTION
Got CI to work. Problem being, it wasn't getting the right Android repository. The built in one is deprecated, I think. Fixed this now. See [related issue here](https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943).

[Previous build report](https://travis-ci.org/Kisty/androidTestRules/builds/244864121)
[Latest build report](https://travis-ci.org/Kisty/androidTestRules/builds/244883590)